### PR TITLE
fix: include functional to use std::function

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <chrono>
+#include <functional>
 #include <thread>
 #include <mutex>
 #include <stack>


### PR DESCRIPTION
I had a build error on
.... The CXX compiler identification is GNU 14.2.0
