### PR TITLE
Optimize AtomicSharedPtr compareExchange

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+/build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(AtomicSharedPtr
     src/lfmap_avl.h
     src/fast_logger.h
     src/atomic_shared_ptr.h
+    src/allocator.h
 )
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
@@ -45,4 +46,9 @@ endif()
 option(TSAN "Enables thread sanitizer" OFF)
 if (TSAN)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=thread")
+endif()
+
+option(ALLOCSAN "Enables allocation sanitizer" OFF)
+if (ALLOCSAN)
+    target_compile_definitions(AtomicSharedPtr PRIVATE "TRACK_ALLOCATIONS=1")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,12 @@ project(AtomicSharedPtr LANGUAGES CXX)
 
 cmake_minimum_required(VERSION 3.8)
 
-set(CMAKE_CXX_STANDARD 17)
+if (MSVC)
+    set(CMAKE_CXX_STANDARD 20)
+else()
+    set(CMAKE_CXX_STANDARD 17)
+endif()
+
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_executable(AtomicSharedPtr

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ AtomicSharedPtr::get() -> SharedPtr:
 
 AtomicSharedPtr::compareExchange():
 - This is actually a strong version
-- 1 AtomicSharedPtr::getFast() + zero or more {fetch_add + CAS + fetch_sub} + one or more CAS
+- 1 AtomicSharedPtr::getFast() + 1 CAS + 1 fetch_sub. One or more fetch_add might be required on active work
 
 I suggest you to look at [queue](https://github.com/vtyulb/AtomicSharedPtr/blob/master/src/lfqueue.h) and
 [stack](https://github.com/vtyulb/AtomicSharedPtr/blob/master/src/lfstack.h) code - life becomes

--- a/src/allocator.h
+++ b/src/allocator.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <cassert>
+#include <mutex>
+#include <memory>
+#include <unordered_set>
+
+#include "fast_logger.h"
+
+struct DefaultAllocator
+{
+	template <class T, class... Args>
+	static T* Allocate(Args&&... args)
+	{
+		return new T(std::forward<Args>(args)...);
+	}
+
+	template <class T>
+	static void Free(T* ptr)
+	{
+		delete ptr;
+	}
+};
+
+struct TrackingAllocator
+{
+	inline static std::mutex Lock;
+	inline static std::unordered_map<void*, const char*> ActiveAllocations;
+	
+	template <class T, class... Args>
+	static T* Allocate(Args&&... args)
+	{
+		auto* ptr = DefaultAllocator::Allocate<T>(std::forward<Args>(args)...);
+
+		{
+			std::unique_lock lock{ Lock };
+			const char* tpn = __FUNCSIG__;
+			ActiveAllocations.insert({ ptr, tpn });
+		}
+
+		return ptr;
+	}
+
+	template <class T>
+	static void Free(T* ptr)
+	{
+		if (ptr)
+		{
+			std::unique_lock lock{ Lock };
+			auto erasedCount = ActiveAllocations.erase(ptr);
+			assert(erasedCount == 1);
+		}
+
+		DefaultAllocator::Free(ptr);
+	}
+
+	static void AssertNoOutstandingAllocations()
+	{
+		std::unique_lock lock{ Lock };
+
+		if (ActiveAllocations.empty())
+			return;
+
+		for (auto allocation : ActiveAllocations)
+		{
+			FAST_LOG(LFStructs::Operation::Leak, reinterpret_cast<size_t>(allocation.first));
+		}
+
+		abort();
+	}
+};
+
+#ifndef ALLOCATOR
+	#ifdef TRACK_ALLOCATIONS
+		#define ALLOCATOR TrackingAllocator
+	#else
+		#define ALLOCATOR DefaultAllocator
+	#endif
+#endif

--- a/src/atomic_shared_ptr.h
+++ b/src/atomic_shared_ptr.h
@@ -76,7 +76,11 @@ public:
         }
         return *this;
     }
-    ~SharedPtr() {
+    ~SharedPtr()
+	{
+        if (controlBlock == nullptr)
+            return;
+
         thread_local std::vector<ControlBlock<T>*> destructionQueue;
         thread_local bool destructionInProgress = false;
 
@@ -219,6 +223,9 @@ public:
 private:
     static void destroyOldControlBlock(size_t oldPackedPtr, int subCount = 1);
 
+	template<bool IsStoreOp>
+    bool compareExchangeImpl(T *expected, SharedPtr<T> &&newOne);
+
     /* first 48 bit - pointer to control block
      * last 16 bit - local refcount if anyone is accessing control block
      * through current AtomicSharedPtr instance right now */
@@ -310,23 +317,40 @@ void AtomicSharedPtr<T>::store(T *data) {
 }
 
 template<typename T>
-void AtomicSharedPtr<T>::store(SharedPtr<T> &&data) {
-    while (true) {
-        auto holder = this->getFast();
-        if (compareExchange(holder.get(), std::move(data))) {
-            break;
-        }
-    }
+void AtomicSharedPtr<T>::store(SharedPtr<T> &&data)
+{
+    auto success = compareExchangeImpl<true>(nullptr, std::move(data));
+    assert(success);
 }
 
 template<typename T>
-bool AtomicSharedPtr<T>::compareExchange(T *expected, SharedPtr<T> &&newOne) {
-    if (expected == newOne.get()) {
-        return true;
+bool AtomicSharedPtr<T>::compareExchange(T *expected, SharedPtr<T> &&newOne)
+{
+    return compareExchangeImpl<false>(expected, std::move(newOne));
+}
+
+template<typename T>
+template<bool IsStoreOp>
+bool AtomicSharedPtr<T>::compareExchangeImpl(T *expected, SharedPtr<T> &&newOne)
+{
+    if constexpr (IsStoreOp == false)
+    {
+	    if (expected == newOne.get())
+			return true;
     }
-    auto holder = this->getFast();
+
+    Reacquire:
+	auto holder = this->getFast();
     FAST_LOG(Operation::CompareAndSwap, reinterpret_cast<size_t>(holder.getControlBlock()));
-    if (holder.get() == expected) {
+
+    if constexpr (IsStoreOp)
+    {
+        if (holder.get() == newOne.get())
+            return true;
+    }
+
+	if (IsStoreOp || holder.get() == expected)
+    {
         auto* controlBlock = holder.getControlBlock();
         size_t holdedPtr = reinterpret_cast<size_t>(controlBlock);
         size_t desiredPackedPtr = reinterpret_cast<size_t>(newOne.controlBlock) << MAGIC_LEN;
@@ -387,6 +411,11 @@ bool AtomicSharedPtr<T>::compareExchange(T *expected, SharedPtr<T> &&newOne) {
 	            "Note that even if `this` still holds that same block, it would have to hold one global count of its own, thus we still can't observe 0 here"
 	        );
         }
+    }
+
+    if constexpr (IsStoreOp)
+    {
+        goto Reacquire;
     }
 
     FAST_LOG(Operation::CASAbrt, reinterpret_cast<size_t>(holder.get()));

--- a/src/atomic_shared_ptr.h
+++ b/src/atomic_shared_ptr.h
@@ -97,12 +97,16 @@ public:
     T* operator->() const { return controlBlock->data; }
 
 private:
-    void unref(ControlBlock<T> *blockToUnref) {
-        if (blockToUnref) {
+    void unref(ControlBlock<T> *blockToUnref)
+	{
+        if (blockToUnref)
+        {
             int before = blockToUnref->refCount.fetch_sub(1);
             assert(before);
-            FAST_LOG(Operation::Unref, (reinterpret_cast<size_t>(blockToUnref) << MAGIC_LEN / 2) | before);
-            if (before == 1) {
+            FAST_LOG(Operation::Unref, reinterpret_cast<size_t>(blockToUnref) << MAGIC_LEN | before);
+
+        	if (before == 1)
+            {
                 FAST_LOG(Operation::ObjectDestroyed, reinterpret_cast<size_t>(blockToUnref));
                 ALLOCATOR::Free(blockToUnref->data);
                 ALLOCATOR::Free(blockToUnref);
@@ -145,16 +149,23 @@ private:
     void destroy() {
         if (foreignPackedPtr != nullptr) {
             size_t expected = knownValue;
-            while (!foreignPackedPtr->compare_exchange_weak(expected, expected - 1)) {
-                if (((expected >> MAGIC_LEN) != (knownValue >> MAGIC_LEN)) || !(expected & MAGIC_MASK)) {
+            while (!foreignPackedPtr->compare_exchange_weak(expected, expected - 1))
+            {
+                if (((expected >> MAGIC_LEN) != (knownValue >> MAGIC_LEN)) || !(expected & MAGIC_MASK))
+                {
                     ControlBlock<T> *block = reinterpret_cast<ControlBlock<T>*>(knownValue >> MAGIC_LEN);
 
                 	size_t before = block->refCount.fetch_sub(1);
+                	FAST_LOG(Operation::FastUnref, ((knownValue >> MAGIC_LEN) << MAGIC_LEN) | before);
+                	assert(before > 0);
+
                     if (before == 1)
                     {
+                        FAST_LOG(Operation::ObjectDestroyed, reinterpret_cast<size_t>(block));
                         ALLOCATOR::Free(data);
                         ALLOCATOR::Free(block);
                     }
+
                     break;
                 }
             }
@@ -328,7 +339,9 @@ bool AtomicSharedPtr<T>::compareExchange(T *expected, SharedPtr<T> &&newOne) {
             int diff = localRefCount - addCredits;
             if (diff > 0) {
                 addCredits = localRefCount;
-                controlBlock->refCount.fetch_add(diff);
+                auto before = controlBlock->refCount.fetch_add(diff);
+				FAST_LOG(Operation::CompareAndSwap_Inc, (expectedPackedPtr & ~MAGIC_MASK) | (before + diff));
+                assert(before > 0);
             }
 
             assert((expectedPackedPtr >> MAGIC_LEN) != (desiredPackedPtr >> MAGIC_LEN));
@@ -346,7 +359,9 @@ bool AtomicSharedPtr<T>::compareExchange(T *expected, SharedPtr<T> &&newOne) {
             int finalCorrection = addCredits - localRefCount + 1;
             assert(finalCorrection > 0);
             controlBlock->refCount.fetch_sub(finalCorrection);
+        	FAST_LOG(Operation::CompareAndSwap_Diff, reinterpret_cast<size_t>(holder.getControlBlock()) << MAGIC_LEN | diff);
 
+        	FAST_LOG(Operation::CompareAndSwap_Diff2, reinterpret_cast<size_t>(holder.getControlBlock()) << MAGIC_LEN | finalCorrection);
             return true;
         }
 

--- a/src/atomic_shared_ptr.h
+++ b/src/atomic_shared_ptr.h
@@ -309,27 +309,41 @@ bool AtomicSharedPtr<T>::compareExchange(T *expected, SharedPtr<T> &&newOne) {
     auto holder = this->getFast();
     FAST_LOG(Operation::CompareAndSwap, reinterpret_cast<size_t>(holder.getControlBlock()));
     if (holder.get() == expected) {
-        size_t holdedPtr = reinterpret_cast<size_t>(holder.getControlBlock());
+        auto* controlBlock = holder.getControlBlock();
+        size_t holdedPtr = reinterpret_cast<size_t>(controlBlock);
         size_t desiredPackedPtr = reinterpret_cast<size_t>(newOne.controlBlock) << MAGIC_LEN;
-        size_t expectedPackedPtr = holdedPtr << MAGIC_LEN;
-        while (holdedPtr == (expectedPackedPtr >> MAGIC_LEN)) {
-            if (expectedPackedPtr & MAGIC_MASK) {
-                int diff = expectedPackedPtr & MAGIC_MASK;
-                holder.getControlBlock()->refCount.fetch_add(diff);
-                if (!packedPtr.compare_exchange_weak(expectedPackedPtr, expectedPackedPtr & ~MAGIC_MASK)) {
-                    holder.getControlBlock()->refCount.fetch_sub(diff);
-                }
+        size_t expectedPackedPtr = holder.knownValue;
+
+        int addCredits = 0;
+        while (true)
+        {
+            int localRefCount = expectedPackedPtr & MAGIC_MASK;
+            int diff = localRefCount - addCredits;
+            if (diff > 0) {
+                addCredits = localRefCount;
+                controlBlock->refCount.fetch_add(diff);
+            }
+
+            assert((expectedPackedPtr >> MAGIC_LEN) != (desiredPackedPtr >> MAGIC_LEN));
+            if (!packedPtr.compare_exchange_weak(expectedPackedPtr, desiredPackedPtr)) {
+                if (holdedPtr != (expectedPackedPtr >> MAGIC_LEN))
+                    break;
+
                 continue;
             }
-            assert((expectedPackedPtr >> MAGIC_LEN) != (desiredPackedPtr >> MAGIC_LEN));
-            if (packedPtr.compare_exchange_weak(expectedPackedPtr, desiredPackedPtr)) {
-                FAST_LOG(Operation::GetInCAS, expectedPackedPtr);
-                newOne.controlBlock = nullptr;
-                assert((expectedPackedPtr >> MAGIC_LEN) == holdedPtr);
-                destroyOldControlBlock(expectedPackedPtr);
-                return true;
-            }
+
+            FAST_LOG(Operation::GetInCAS, expectedPackedPtr);
+            newOne.controlBlock = nullptr;
+            assert((expectedPackedPtr >> MAGIC_LEN) == holdedPtr);
+
+            int finalCorrection = addCredits - localRefCount + 1;
+            assert(finalCorrection > 0);
+            controlBlock->refCount.fetch_sub(finalCorrection);
+
+            return true;
         }
+
+        controlBlock->refCount.fetch_sub(addCredits);
     }
 
     FAST_LOG(Operation::CASAbrt, reinterpret_cast<size_t>(holder.get()));

--- a/src/atomic_shared_ptr.h
+++ b/src/atomic_shared_ptr.h
@@ -7,6 +7,7 @@
 #include <thread>
 #include <stack>
 
+#include "allocator.h"
 #include "fast_logger.h"
 
 namespace LFStructs {
@@ -29,17 +30,20 @@ struct alignas(CACHE_LINE_SIZE) ControlBlock {
     std::atomic<size_t> refCount;
 };
 
-
 template<typename T>
 class SharedPtr {
 public:
     SharedPtr(): controlBlock(nullptr) {}
-    explicit SharedPtr(T *data)
-        : controlBlock(new ControlBlock<T>(data))
+    explicit SharedPtr(T *data) :
+		controlBlock(ALLOCATOR::Allocate<ControlBlock<T>>(data))
     {
         FAST_LOG(Operation::ObjectCreated, reinterpret_cast<size_t>(controlBlock));
     }
-    explicit SharedPtr(ControlBlock<T> *controlBlock): controlBlock(controlBlock) {}
+
+    explicit SharedPtr(ControlBlock<T> *controlBlock) :
+		controlBlock(controlBlock)
+	{}
+
     SharedPtr(const SharedPtr &other) {
         controlBlock = other.controlBlock;
         if (controlBlock != nullptr) {
@@ -100,8 +104,8 @@ private:
             FAST_LOG(Operation::Unref, (reinterpret_cast<size_t>(blockToUnref) << MAGIC_LEN / 2) | before);
             if (before == 1) {
                 FAST_LOG(Operation::ObjectDestroyed, reinterpret_cast<size_t>(blockToUnref));
-                delete blockToUnref->data;
-                delete blockToUnref;
+                ALLOCATOR::Free(blockToUnref->data);
+                ALLOCATOR::Free(blockToUnref);
             }
         }
     }
@@ -144,10 +148,12 @@ private:
             while (!foreignPackedPtr->compare_exchange_weak(expected, expected - 1)) {
                 if (((expected >> MAGIC_LEN) != (knownValue >> MAGIC_LEN)) || !(expected & MAGIC_MASK)) {
                     ControlBlock<T> *block = reinterpret_cast<ControlBlock<T>*>(knownValue >> MAGIC_LEN);
-                    size_t before = block->refCount.fetch_sub(1);
-                    if (before == 1) {
-                        delete data;
-                        delete block;
+
+                	size_t before = block->refCount.fetch_sub(1);
+                    if (before == 1)
+                    {
+                        ALLOCATOR::Free(data);
+                        ALLOCATOR::Free(block);
                     }
                     break;
                 }
@@ -210,8 +216,9 @@ private:
 };
 
 template<typename T>
-AtomicSharedPtr<T>::AtomicSharedPtr(T *data) {
-    auto block = new ControlBlock(data);
+AtomicSharedPtr<T>::AtomicSharedPtr(T *data)
+{
+    auto block = ALLOCATOR::Allocate<ControlBlock<T>>(data);
     packedPtr.store(reinterpret_cast<size_t>(block) << MAGIC_LEN);
 }
 
@@ -361,8 +368,8 @@ void AtomicSharedPtr<T>::destroyOldControlBlock(size_t oldPackedPtr) {
     assert(refCountBefore);
     if (refCountBefore == 1) {
         FAST_LOG(Operation::ObjectDestroyed, reinterpret_cast<size_t>(block));
-        delete block->data;
-        delete block;
+        ALLOCATOR::Free(block->data);
+        ALLOCATOR::Free(block);
     }
     FAST_LOG(Operation::CASFin, oldPackedPtr);
 }

--- a/src/atomic_shared_ptr.h
+++ b/src/atomic_shared_ptr.h
@@ -217,7 +217,7 @@ public:
     void store(SharedPtr<T>&& data);
 
 private:
-    void destroyOldControlBlock(size_t oldPackedPtr);
+    static void destroyOldControlBlock(size_t oldPackedPtr, int subCount = 1);
 
     /* first 48 bit - pointer to control block
      * last 16 bit - local refcount if anyone is accessing control block
@@ -336,18 +336,21 @@ bool AtomicSharedPtr<T>::compareExchange(T *expected, SharedPtr<T> &&newOne) {
         while (true)
         {
             int localRefCount = expectedPackedPtr & MAGIC_MASK;
+
             int diff = localRefCount - addCredits;
-            if (diff > 0) {
-                addCredits = localRefCount;
+            if (diff > 1)
+            {
+                addCredits += diff;
                 auto before = controlBlock->refCount.fetch_add(diff);
 				FAST_LOG(Operation::CompareAndSwap_Inc, (expectedPackedPtr & ~MAGIC_MASK) | (before + diff));
                 assert(before > 0);
             }
 
             assert((expectedPackedPtr >> MAGIC_LEN) != (desiredPackedPtr >> MAGIC_LEN));
-            if (!packedPtr.compare_exchange_weak(expectedPackedPtr, desiredPackedPtr)) {
+            if (packedPtr.compare_exchange_weak(expectedPackedPtr, desiredPackedPtr) == false)
+            {
                 if (holdedPtr != (expectedPackedPtr >> MAGIC_LEN))
-                    break;
+                	break;
 
                 continue;
             }
@@ -356,16 +359,34 @@ bool AtomicSharedPtr<T>::compareExchange(T *expected, SharedPtr<T> &&newOne) {
             newOne.controlBlock = nullptr;
             assert((expectedPackedPtr >> MAGIC_LEN) == holdedPtr);
 
-            int finalCorrection = addCredits - localRefCount + 1;
-            assert(finalCorrection > 0);
-            controlBlock->refCount.fetch_sub(finalCorrection);
         	FAST_LOG(Operation::CompareAndSwap_Diff, reinterpret_cast<size_t>(holder.getControlBlock()) << MAGIC_LEN | diff);
 
+            int correctionForGlobalCounter = addCredits - localRefCount;
+            assert(correctionForGlobalCounter >= -1 && "The global ref count must be either on point, overshoot some, or exactly one down for `holder` it did not count in");
+
+            int finalCorrection = correctionForGlobalCounter;
+            finalCorrection += /*Yielding `holder` ownership*/ 1;
+            finalCorrection += /*Yielding `this` ownership*/ 1;
         	FAST_LOG(Operation::CompareAndSwap_Diff2, reinterpret_cast<size_t>(holder.getControlBlock()) << MAGIC_LEN | finalCorrection);
+			destroyOldControlBlock(expectedPackedPtr, finalCorrection);
+            holder.foreignPackedPtr = nullptr;
+
             return true;
         }
 
-        controlBlock->refCount.fetch_sub(addCredits);
+        if (addCredits)
+        {
+	        assert(addCredits > 0);
+
+	        auto before = controlBlock->refCount.fetch_sub(addCredits);
+	        assert
+			(
+	            before > 0 && 
+	            "At least `holder` must still have 1 active count by now"
+	            "That count must be now promoted to global by someone who exchanged block in `this`, otherwise we'd be still CASing"
+	            "Note that even if `this` still holds that same block, it would have to hold one global count of its own, thus we still can't observe 0 here"
+	        );
+        }
     }
 
     FAST_LOG(Operation::CASAbrt, reinterpret_cast<size_t>(holder.get()));
@@ -373,19 +394,24 @@ bool AtomicSharedPtr<T>::compareExchange(T *expected, SharedPtr<T> &&newOne) {
 }
 
 template<typename T>
-void AtomicSharedPtr<T>::destroyOldControlBlock(size_t oldPackedPtr) {
+void AtomicSharedPtr<T>::destroyOldControlBlock(size_t oldPackedPtr, int subCount)
+{
+    assert(subCount > 0);
     FAST_LOG(Operation::CASDestructed, oldPackedPtr);
 //    assert((oldPackedPtr & MAGIC_MASK) == 0);
 
     auto block = reinterpret_cast<ControlBlock<T>*>(oldPackedPtr >> MAGIC_LEN);
-    auto refCountBefore = block->refCount.fetch_sub(1);
-    FAST_LOG(Operation::Unref, refCountBefore);
-    assert(refCountBefore);
-    if (refCountBefore == 1) {
+    auto newRefCount = block->refCount.fetch_sub(subCount) - subCount;
+    FAST_LOG(Operation::Unref, ((oldPackedPtr >> MAGIC_LEN) << MAGIC_LEN) | newRefCount);
+    assert(newRefCount >= 0);
+
+	if (newRefCount == 0)
+    {
         FAST_LOG(Operation::ObjectDestroyed, reinterpret_cast<size_t>(block));
         ALLOCATOR::Free(block->data);
         ALLOCATOR::Free(block);
     }
+
     FAST_LOG(Operation::CASFin, oldPackedPtr);
 }
 

--- a/src/fast_logger.h
+++ b/src/fast_logger.h
@@ -74,6 +74,7 @@ struct Operation {
 class FastLogger {
     struct Storage {
         std::mutex lock;
+        std::vector<std::vector<Operation>> pastOperations;
         std::vector<std::pair<std::thread::id, std::vector<Operation>*>> containers;
     };
 
@@ -87,8 +88,11 @@ public:
 
     ~FastLogger() {
         std::lock_guard guard{storage.lock};
-        for (auto i = storage.containers.begin(); i != storage.containers.end(); i++) {
-            if (i->first == std::this_thread::get_id()) {
+        for (auto i = storage.containers.begin(); i != storage.containers.end(); i++)
+        {
+            if (i->first == std::this_thread::get_id())
+            {
+                storage.pastOperations.emplace_back(std::move(data));
                 storage.containers.erase(i);
                 return;
             }
@@ -109,8 +113,22 @@ public:
     static void PrintTrace() {
         std::vector<std::pair<int, Operation>> ops;
         for (int threadNumber = 0; threadNumber < storage.containers.size(); threadNumber++)
-            for (const auto threadLocalOperation : *storage.containers[threadNumber].second)
+        for (const auto threadLocalOperation : *storage.containers[threadNumber].second)
+        {
+	        if (threadLocalOperation.time != 0)
+	        {
                 ops.push_back(std::make_pair(threadNumber, threadLocalOperation));
+	        }
+        }
+
+        for (auto& pastOps : storage.pastOperations)
+        for (const auto op : pastOps)
+        {
+            if (op.time != 0)
+            {
+				ops.push_back(std::make_pair(-1, op));
+            }
+        }
 
         std::sort(ops.begin(), ops.end(), [](const auto& a, const auto& b){
             return a.second.time < b.second.time;

--- a/src/fast_logger.h
+++ b/src/fast_logger.h
@@ -14,9 +14,13 @@
 namespace LFStructs {
 
 static uint64_t rdtsc() {
+#ifdef _MSC_VER
+    return __rdtsc();
+#else
     unsigned int lo,hi;
     __asm__ __volatile__ ("rdtsc" : "=a" (lo), "=d" (hi));
     return ((uint64_t)hi << 32) | lo;
+#endif
 }
 
 struct Operation {

--- a/src/fast_logger.h
+++ b/src/fast_logger.h
@@ -49,6 +49,13 @@ struct Operation {
         Ref        = 50,
         Unref      = 51,
 
+    	Leak      = 80,
+
+    	CompareAndSwap_Diff = 90,
+    	CompareAndSwap_Diff2 = 91,
+    	CompareAndSwap_Inc = 92,
+    	FastUnref = 93,
+
         ObjectCreated = 100,
         ObjectDestroyed = 101
     } type;

--- a/src/fast_logger.h
+++ b/src/fast_logger.h
@@ -11,11 +11,20 @@
 #include <vector>
 #include <deque>
 
+#ifdef _MSC_VER
+#define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
 namespace LFStructs {
 
-static uint64_t rdtsc() {
+static uint64_t rdtsc()
+{
 #ifdef _MSC_VER
-    return __rdtsc();
+    LARGE_INTEGER value;
+    QueryPerformanceCounter(&value);
+    return value.QuadPart;
 #else
     unsigned int lo,hi;
     __asm__ __volatile__ ("rdtsc" : "=a" (lo), "=d" (hi));

--- a/src/lfmap.h
+++ b/src/lfmap.h
@@ -54,7 +54,7 @@ std::optional<Value> LFMap<Key, Value>::get(Key key) {
 
 template<typename Key, typename Value>
 void LFMap<Key, Value>::upsert(Key key, Value value) {
-    SharedPtr node(new Node());
+    SharedPtr node(ALLOCATOR::Allocate<Node>());
     node->key = key;
     node->data = value;
     node->size = 1;
@@ -90,7 +90,7 @@ SharedPtr<typename LFMap<Key, Value>::Node> LFMap<Key, Value>::merge(const Share
     if (right.get() == nullptr)
         return left;
 
-    SharedPtr<Node> root(new Node());
+    SharedPtr<Node> root(ALLOCATOR::Allocate<Node>());
     root->size = left->size + right->size;
     if (rand() * uint64_t(left->size + right->size) < left->size * RAND_MAX) {
         root->key = left->key;
@@ -116,7 +116,7 @@ LFMap<Key, Value>::splitLess(const SharedPtr<Node> &root, Key key) {
     if (root->key < key) {
         auto [rightLeft, rightRight] = splitLess(root->right, key);
 
-        SharedPtr node(new Node());
+        SharedPtr node(ALLOCATOR::Allocate<Node>());
         node->key = root->key;
         node->data = root->data;
         node->left = root->left;
@@ -127,7 +127,7 @@ LFMap<Key, Value>::splitLess(const SharedPtr<Node> &root, Key key) {
     } else {
         auto [leftLeft, leftRight] = splitLess(root->left, key);
 
-        SharedPtr node(new Node());
+        SharedPtr node(ALLOCATOR::Allocate<Node>());
         node->key = root->key;
         node->data = root->data;
         node->left = leftRight;
@@ -147,7 +147,7 @@ LFMap<Key, Value>::splitLessEq(const SharedPtr<Node> &root, Key key) {
     if (!(key < root->key)) {
         auto [rightLeft, rightRight] = splitLessEq(root->right, key);
 
-        SharedPtr node(new Node());
+        SharedPtr node(ALLOCATOR::Allocate<Node>());
         node->key = root->key;
         node->data = root->data;
         node->left = root->left;
@@ -158,7 +158,7 @@ LFMap<Key, Value>::splitLessEq(const SharedPtr<Node> &root, Key key) {
     } else {
         auto [leftLeft, leftRight] = splitLessEq(root->left, key);
 
-        SharedPtr node(new Node());
+        SharedPtr node(ALLOCATOR::Allocate<Node>());
         node->key = root->key;
         node->data = root->data;
         node->left = leftRight;

--- a/src/lfmap_avl.h
+++ b/src/lfmap_avl.h
@@ -92,14 +92,14 @@ std::optional<Value> LFMapAvl<Key, Value>::get(Key key) {
 template<typename Key, typename Value>
 SharedPtr<typename LFMapAvl<Key, Value>::Node> LFMapAvl<Key, Value>::upsert(const SharedPtr<Node> &root, Key key, Value data) {
     if (root.get() == nullptr) {
-        SharedPtr<Node> res(new Node());
+        SharedPtr<Node> res(ALLOCATOR::Allocate<Node>());
         res->key = key;
         res->data = data;
         res->height = 1;
         return res;
     }
 
-    SharedPtr<Node> newRoot(new Node());
+    SharedPtr<Node> newRoot(ALLOCATOR::Allocate<Node>());
     newRoot->key = root->key;
     newRoot->data = root->data;
 
@@ -145,14 +145,14 @@ SharedPtr<typename LFMapAvl<Key, Value>::Node> LFMapAvl<Key, Value>::balance(con
 
 template<typename Key, typename Value>
 SharedPtr<typename LFMapAvl<Key, Value>::Node> LFMapAvl<Key, Value>::rotateLeft(const SharedPtr<Node> &root) {
-    SharedPtr<Node> a(new Node());
+    SharedPtr<Node> a(ALLOCATOR::Allocate<Node>());
     a->key = root->key;
     a->data = root->data;
     a->left = root->left;
     a->right = root->right->left;
     a->updateHeight();
 
-    SharedPtr<Node> b(new Node());
+    SharedPtr<Node> b(ALLOCATOR::Allocate<Node>());
     b->key = root->right->key;
     b->data = root->right->data;
     b->left = std::move(a);
@@ -164,14 +164,14 @@ SharedPtr<typename LFMapAvl<Key, Value>::Node> LFMapAvl<Key, Value>::rotateLeft(
 
 template<typename Key, typename Value>
 SharedPtr<typename LFMapAvl<Key, Value>::Node> LFMapAvl<Key, Value>::rotateRight(const SharedPtr<Node> &root) {
-    SharedPtr<Node> a(new Node());
+    SharedPtr<Node> a(ALLOCATOR::Allocate<Node>());
     a->key = root->key;
     a->data = root->data;
     a->left = root->left->right;
     a->right = root->right;
     a->updateHeight();
 
-    SharedPtr<Node> b(new Node());
+    SharedPtr<Node> b(ALLOCATOR::Allocate<Node>());
     b->key = root->left->key;
     b->data = root->left->data;
     b->left = root->left->left;
@@ -183,21 +183,21 @@ SharedPtr<typename LFMapAvl<Key, Value>::Node> LFMapAvl<Key, Value>::rotateRight
 
 template<typename Key, typename Value>
 SharedPtr<typename LFMapAvl<Key, Value>::Node> LFMapAvl<Key, Value>::bigRotateLeft(const SharedPtr<Node> &root) {
-    SharedPtr<Node> a(new Node());
+    SharedPtr<Node> a(ALLOCATOR::Allocate<Node>());
     a->key = root->key;
     a->data = root->data;
     a->left = root->left;
     a->right = root->right->left->left;
     a->updateHeight();
 
-    SharedPtr<Node> b(new Node());
+    SharedPtr<Node> b(ALLOCATOR::Allocate<Node>());
     b->key = root->right->key;
     b->data = root->right->data;
     b->left = root->right->left->right;
     b->right = root->right->right;
     b->updateHeight();
 
-    SharedPtr<Node> c(new Node());
+    SharedPtr<Node> c(ALLOCATOR::Allocate<Node>());
     c->key = root->right->left->key;
     c->data = root->right->left->data;
     c->left = std::move(a);
@@ -209,21 +209,21 @@ SharedPtr<typename LFMapAvl<Key, Value>::Node> LFMapAvl<Key, Value>::bigRotateLe
 
 template<typename Key, typename Value>
 SharedPtr<typename LFMapAvl<Key, Value>::Node> LFMapAvl<Key, Value>::bigRotateRight(const SharedPtr<Node> &root) {
-    SharedPtr<Node> a(new Node());
+    SharedPtr<Node> a(ALLOCATOR::Allocate<Node>());
     a->key = root->key;
     a->data = root->data;
     a->left = root->left->right->right;
     a->right = root->right;
     a->updateHeight();
 
-    SharedPtr<Node> b(new Node());
+    SharedPtr<Node> b(ALLOCATOR::Allocate<Node>());
     b->key = root->left->key;
     b->data = root->left->data;
     b->left = root->left->left;
     b->right = root->left->right->left;
     b->updateHeight();
 
-    SharedPtr<Node> c(new Node());
+    SharedPtr<Node> c(ALLOCATOR::Allocate<Node>());
     c->key = root->left->right->key;
     c->data = root->left->right->data;
     c->left = std::move(b);
@@ -243,7 +243,7 @@ SharedPtr<typename LFMapAvl<Key, Value>::Node> LFMapAvl<Key, Value>::remove(cons
         if (newRight.get() == root->right.get())
             return root;
 
-        SharedPtr<Node> newRoot(new Node());
+        SharedPtr<Node> newRoot(ALLOCATOR::Allocate<Node>());
         newRoot->key = root->key;
         newRoot->data = root->data;
         newRoot->left = root->left;
@@ -256,7 +256,7 @@ SharedPtr<typename LFMapAvl<Key, Value>::Node> LFMapAvl<Key, Value>::remove(cons
         if (newLeft.get() == root->left.get())
             return root;
 
-        SharedPtr<Node> newRoot(new Node());
+        SharedPtr<Node> newRoot(ALLOCATOR::Allocate<Node>());
         newRoot->key = root->key;
         newRoot->data = root->data;
         newRoot->left = std::move(newLeft);
@@ -274,7 +274,7 @@ SharedPtr<typename LFMapAvl<Key, Value>::Node> LFMapAvl<Key, Value>::remove(cons
             while (targetLeft->right.get() != nullptr)
                 targetLeft = targetLeft->right.get();
 
-            SharedPtr<Node> newRoot(new Node());
+            SharedPtr<Node> newRoot(ALLOCATOR::Allocate<Node>());
             newRoot->key = targetLeft->key;
             newRoot->data = targetLeft->data;
             newRoot->left = remove(root->left, targetLeft->key);
@@ -286,7 +286,7 @@ SharedPtr<typename LFMapAvl<Key, Value>::Node> LFMapAvl<Key, Value>::remove(cons
             while (targetRight->left.get() != nullptr)
                 targetRight = targetRight->left.get();
 
-            SharedPtr<Node> newRoot(new Node());
+            SharedPtr<Node> newRoot(ALLOCATOR::Allocate<Node>());
             newRoot->key = targetRight->key;
             newRoot->data = targetRight->data;
             newRoot->left = root->left;

--- a/src/lfqueue.h
+++ b/src/lfqueue.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "allocator.h"
 #include "atomic_shared_ptr.h"
 
 namespace LFStructs {
@@ -25,7 +26,7 @@ private:
 
 template<typename T>
 LFQueue<T>::LFQueue() {
-    auto node = new Node { };
+    auto node = ALLOCATOR::Allocate<Node>();
     node->consumed.test_and_set(std::memory_order::relaxed);
 	auto fakeNode = SharedPtr(node);
 
@@ -36,9 +37,11 @@ LFQueue<T>::LFQueue() {
 template<typename T>
 void LFQueue<T>::push(const T &data) {
     FAST_LOG(Operation::Push, data);
-    auto newBack = SharedPtr(new Node{
-                                 .data = data
-                             });
+
+	auto node = ALLOCATOR::Allocate<Node>();
+    node->data = data;
+
+	auto newBack = SharedPtr(node);
 
     while (true) {
         FastSharedPtr<Node> currentBack = back.getFast();

--- a/src/lfqueue.h
+++ b/src/lfqueue.h
@@ -25,9 +25,9 @@ private:
 
 template<typename T>
 LFQueue<T>::LFQueue() {
-    auto fakeNode = SharedPtr(new Node{
-                                  .consumed = true
-                              });
+    auto node = new Node { };
+    node->consumed.test_and_set(std::memory_order::relaxed);
+	auto fakeNode = SharedPtr(node);
 
     front.compareExchange(nullptr, fakeNode.copy());
     back.compareExchange(nullptr, std::move(fakeNode));

--- a/src/lfstack.h
+++ b/src/lfstack.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <optional>
 
+#include "allocator.h"
 #include "atomic_shared_ptr.h"
 
 namespace LFStructs {
@@ -27,7 +28,7 @@ private:
 template<typename T>
 void LFStack<T>::push(const T &data) {
     FAST_LOG(Operation::Push, data);
-    SharedPtr<Node> newTop(new Node());
+    SharedPtr<Node> newTop(ALLOCATOR::Allocate<Node>());
     newTop->next = top.get();
     newTop->data = data;
     while (!top.compareExchange(newTop->next.get(), std::move(newTop))) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@
 #include <map>
 #include <csignal>
 
+#include "allocator.h"
 #include "lfstack.h"
 #include "lfqueue.h"
 #include "lfmap.h"
@@ -21,15 +22,23 @@ void check(bool good) {
         abort();
 }
 
-void atomic_shared_ptr_concurrent_store_load_test() {
+void AssertNoOutstandingBlocks()
+{
+#ifdef TRACK_ALLOCATIONS
+    TrackingAllocator::AssertNoOutstandingAllocations();
+#endif
+}
+
+void atomic_shared_ptr_concurrent_store_load_test()
+{
     printf("running AtomicSharedPtr load/store test...\n");
     const auto threadCount = std::thread::hardware_concurrency();
-    LFStructs::AtomicSharedPtr<int> sp(new int(0));
+    LFStructs::AtomicSharedPtr<int> sp(ALLOCATOR::Allocate<int>(0));
     std::vector<std::thread> threads;
     for (unsigned i = 0; i < threadCount/2; i++) {
         threads.emplace_back([&sp]{
             for (int j = 0; j < 1000000; j++)
-                sp.store(new int(42));
+                sp.store(ALLOCATOR::Allocate<int>(42));
         });
     }
     for (unsigned i = threadCount/2; i < threadCount; i++) {
@@ -315,10 +324,20 @@ void abortTraceLogger(int sig) {
 
 int main()
 {
+    AssertNoOutstandingBlocks();
     signal(SIGABRT, abortTraceLogger);
+
     atomic_shared_ptr_concurrent_store_load_test();
-    all_map_tests();
-    all_queue_tests();
-    all_stack_tests();
-    return 0;
+    AssertNoOutstandingBlocks();
+
+	all_map_tests();
+    AssertNoOutstandingBlocks();
+
+	all_queue_tests();
+    AssertNoOutstandingBlocks();
+
+	all_stack_tests();
+    AssertNoOutstandingBlocks();
+
+	return 0;
 }


### PR DESCRIPTION
Hello,
I was checking your implementation of AtomicSharedPtr,
the early propagation of local ref count to control block in `compareExchange` is pure genius, very nice trick 👌 

When playing with it a bit, I noticed it can be slimmed down a bit, from 8 barriers ops I'm down to 2.
More info in commit message: https://github.com/InflexCZE/AtomicSharedPtr/commit/f16d657e0b324d6728910477f23cf3c620d46643

Tests pass (even tho that means nothing in threading 🙃),
I'm quite confident I did not break anything, but would still like to hear your expert opinion/review.

Benchmarks show some nice preliminary perf improvements:
|LFQueue |  1   |  2   |  3   |  4    |  5    |  6    |  7    |  8    | |     
|- |  -   |  -   |  -   |  -    |  -    |  -    |  -    |  -          | - |       
|2000000 |  873 |  844 |  899 |  1017 |  1099 |  1208 |  1325 |  1420 | (Before) |
|2000000 |  718 |  732 |  731 |  791  |  828  |  803  |  922  |  918  | (After) |
|=       | -22% | -15% | -23% | -29%  | -33%  | -50%  | -44%  | -55%  | |

| LFStack |  1   |  2   |  3    |  4    |  5    |  6    |  7    |  8 | |
| - |  -   |  -   |  -   |  -    |  -    |  -    |  -    |  -          | - |       
| 2000000 |  609 |  925 |  1272 |  1564 |  1800 |  2008 |  2211 |  2345 | (Before) |
| 2000000 |  527 |  718 |  908  |  1148 |  1319 |  1522 |  1632 |  1649 | (After) |
| =       | -16% | -29% | -40%  | -36%  | -36%  | -32%  | -35%  | -42%  | |

PS: I have no idea how to PR single commit, it pulled also fixes for MSVC compilation. Hope it's not a problem.


i7 9700k
Microsoft (R) C/C++ Optimizing Compiler Version 19.44.35211 for x64
<details>
<summary>Before (Relase)</summary>
running AtomicSharedPtr load/store test...
running simple LFMap test...
running simple LFMapAvl test...

running correctness LFMap test...
0%  10%  20%  30%  40%  50%  60%  70%  80%  90%  100%

running correctness LFMapAvl test...
0%  10%  20%  30%  40%  50%  60%  70%  80%  90%  100%

running LFMap stress test...
        1       2       3       4       5       6       7       8
500000  296     293     267     258     250     260     240     249
1000000 497     435     412     387     392     386     398     356
1500000 676     704     519     578     519     504     484     466
2000000 765     786     696     702     696     659     598     589

running LFMapAvl stress test...
        1       2       3       4       5       6       7       8
500000  115     97      87      84      83      83      82      82
1000000 201     152     139     130     129     129     127     132
1500000 267     222     186     178     176     174     175     176
2000000 380     272     237     226     223     224     223     222

running lockable map stress test
        1       2       3       4       5       6       7       8
500000  23      28      33      35      37      41      45      45
1000000 43      51      61      69      74      82      88      95
1500000 64      80      89      100     112     115     130     138
2000000 85      104     122     131     150     155     173     193


running simple LFQueue test...

running LFQueue stress test...
        1       2       3       4       5       6       7       8
500000  216     215     225     253     279     302     330     355
1000000 441     426     453     508     554     609     673     720
1500000 651     643     677     760     825     911     1003    1069
2000000 873     844     899     1017    1099    1208    1325    1420

running lockable queue stress test...
        1       2       3       4       5       6       7       8
500000  19      24      30      33      35      38      43      44
1000000 38      46      60      64      73      82      88      89
1500000 57      72      89      103     108     121     126     144
2000000 78      98      114     132     149     162     175     193

running simple LFStack test...

running LFStack stress test...
        1       2       3       4       5       6       7       8
500000  159     234     310     387     450     504     544     592
1000000 308     462     635     782     902     1010    1094    1170
1500000 461     684     948     1168    1348    1500    1639    1730
2000000 609     925     1272    1564    1800    2008    2211    2345

running lockable stack stress test...
        1       2       3       4       5       6       7       8
500000  20      26      32      34      41      40      46      49
1000000 39      50      63      72      77      82      94      99
1500000 57      78      90      110     119     128     138     149
2000000 79      103     120     141     155     178     186     190
</details>


<details>
<summary>After (Relase)</summary>
running AtomicSharedPtr load/store test...
running simple LFMap test...
running simple LFMapAvl test...

running correctness LFMap test...
0%  10%  20%  30%  40%  50%  60%  70%  80%  90%  100%

running correctness LFMapAvl test...
0%  10%  20%  30%  40%  50%  60%  70%  80%  90%  100%

running LFMap stress test...
        1       2       3       4       5       6       7       8
500000  304     289     263     262     250     258     240     260
1000000 485     440     415     389     395     389     410     363
1500000 676     699     514     587     509     498     480     469
2000000 732     796     716     721     694     661     601     593

running LFMapAvl stress test...
        1       2       3       4       5       6       7       8
500000  122     100     84      86      87      80      81      83
1000000 198     158     136     128     122     119     117     118
1500000 277     218     187     170     166     157     161     158
2000000 366     269     230     216     209     200     200     199

running lockable map stress test
        1       2       3       4       5       6       7       8
500000  23      32      35      39      44      48      47      49
1000000 45      57      65      73      78      82      94      95
1500000 65      82      93      112     116     133     134     133
2000000 88      109     131     145     165     162     208     189


running simple LFQueue test...

running LFQueue stress test...
        1       2       3       4       5       6       7       8
500000  207     195     188     198     210     221     229     243
1000000 377     371     368     394     416     442     449     472
1500000 547     551     546     587     625     662     693     686
2000000 718     732     731     791     828     803     922     918

running lockable queue stress test...
        1       2       3       4       5       6       7       8
500000  19      25      31      36      38      41      44      46
1000000 38      51      58      69      76      85      90      92
1500000 58      75      91      105     114     126     135     135
2000000 79      108     127     142     158     169     179     183

running simple LFStack test...

running LFStack stress test...
        1       2       3       4       5       6       7       8
500000  137     180     229     284     332     369     404     389
1000000 265     364     450     571     659     768     775     806
1500000 391     542     676     835     917     1081    1144    1232
2000000 527     718     908     1148    1319    1522    1632    1649

running lockable stack stress test...
        1       2       3       4       5       6       7       8
500000  19      26      31      34      40      42      47      46
1000000 38      47      64      67      76      86      88      92
1500000 56      81      93      105     116     129     138     139
2000000 77      98      122     141     159     171     181     176
</details>


